### PR TITLE
Edit STV algorithm to eliminate zero vote candidates only once a non-zero vote elimination occurs

### DIFF
--- a/functions/src/vote/vote.ts
+++ b/functions/src/vote/vote.ts
@@ -70,7 +70,7 @@ function stv(winners, ballots, choices) {
     if (threshold <= mx) {
       winners--;
       elim = Object.entries(name2totals).filter(x=>x[1]===mx)[0][0];
-      elected.push(elim);
+      elected.push({"name": elim, "votes": name2totals[elim], "round": (rounds.length-1)});
       factor = (mx-threshold)/mx;
     } else {
 
@@ -80,13 +80,13 @@ function stv(winners, ballots, choices) {
       let mn_keys = Object.entries(name2totals).filter(x=> x[1]===mn).map(x=>x[0]);
       // @ts-ignore
       elim = mn_keys[parseInt((Math.random())*mn_keys.length)];
-      eleminated.push({"round": (rounds.length-1), "name": elim, "from": mn_keys.length});
+      eleminated.push({"round": (rounds.length-1), "name": elim, "from": mn_keys.length, "votes": name2totals[elim]});
       factor = 1;
 
       //remove zero vote candidates
       let mn_zero_keys = Object.entries(name2totals).filter(x=> x[1]===0 && !eleminated.map(x=>x['name']).includes(x[0])).map(x=>x[0]);
       mn_zero_keys.forEach(key =>
-          eleminated.push({"round": (rounds.length-1), "name": key, "from": -1})
+          eleminated.push({"round": (rounds.length-1), "name": key, "from": -1, "votes": name2totals[key]})
       );
       mn_zero_keys.forEach(key => delete name2totals[key]);
     }

--- a/functions/src/vote/vote.ts
+++ b/functions/src/vote/vote.ts
@@ -74,8 +74,9 @@ function stv(winners, ballots, choices) {
       factor = (mx-threshold)/mx;
     } else {
 
+      // find non-zero vote loser
       // @ts-ignore
-      let mn = Math.min(...Object.values(name2totals));
+      let mn = Math.min(...Object.values(name2totals).filter(x => x!==0));
       let mn_keys = Object.entries(name2totals).filter(x=> x[1]===mn).map(x=>x[0]);
       // @ts-ignore
       elim = mn_keys[parseInt((Math.random())*mn_keys.length)];
@@ -83,9 +84,9 @@ function stv(winners, ballots, choices) {
       factor = 1;
 
       //remove zero vote candidates
-      let mn_zero_keys = Object.entries(name2totals).filter(x=> x[1]===0).map(x=>x[0]);
+      let mn_zero_keys = Object.entries(name2totals).filter(x=> x[1]===0 && !eleminated.map(x=>x['name']).includes(x[0])).map(x=>x[0]);
       mn_zero_keys.forEach(key =>
-        eleminated.push({"round": (rounds.length-1), "name": key, "from": -1})
+          eleminated.push({"round": (rounds.length-1), "name": key, "from": -1})
       );
       mn_zero_keys.forEach(key => delete name2totals[key]);
     }
@@ -107,7 +108,6 @@ function stv(winners, ballots, choices) {
   }
   return {"elected": elected, "rounds": rounds, "threshold": threshold, "eleminated": eleminated};
 }
-
 
 function calculateResults(winners, ballots, choices) {
   console.log('calculate results with...', winners, ballots, choices);


### PR DESCRIPTION
Hi Trey,

I've looked at the STV algorithm and made some changes that should make it behave as we want (only eliminating zero vote candidates once an elimination round is reached). I've got the function working and tested on my end. Two things though: 

- Would you be able to change the call to `calculateResults` to include the "choices" variable? I changed the stv function call to accept the "choices" variable as a third argument. I'm not familiar with firebase and not exactly sure how to access that variable.

- Part of what's returned by the stv function is a field called "eleminated" that contains dictionaries for each eliminated candidate. Each dictionary include the eliminated candidate's name, the round eliminated, and a "from" field that indicates which candidate was eliminated in that round, if there were multiple possible elimination candidates with the same "losing" round total.  I wasn't exactly sure how to fill this in for the zero-vote candidates when they are eliminated because I'm not sure how you use this field later on. Right now I fill it with a -1 for zero-vote eliminations. Let me know if my change here messes things up.

Also, let me know if I should pull request into a different branch.

Best,
Chris
